### PR TITLE
Fix the position (0,0) bug.

### DIFF
--- a/src/slider/RangeSliderUI.java
+++ b/src/slider/RangeSliderUI.java
@@ -395,7 +395,7 @@ class RangeSliderUI extends BasicSliderUI {
             // otherwise check the position of the lower thumb first.
             boolean lowerPressed = false;
             boolean upperPressed = false;
-            if (upperThumbSelected) {
+            if (upperThumbSelected || slider.getMinimum() == slider.getValue()) {
                 if (upperThumbRect.contains(currentMouseX, currentMouseY)) {
                     upperPressed = true;
                 } else if (thumbRect.contains(currentMouseX, currentMouseY)) {


### PR DESCRIPTION
It was impossible to move sliders if it is initialized with `value = upperValue = minimum`. Add a condition to fix it.
